### PR TITLE
Allow use of resize functions, simplify wrapper.h, and fix README name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libparted-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Chris Holcombe <xfactor973@gmail.com>"]
 license = "MIT"
 description = "libparted bindings"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# block-utils
+# libparted-sys
 [![Docs](https://docs.rs/libparted-sys/badge.svg)](https://docs.rs/libparted-syss)[![Crates.io](https://img.shields.io/crates/v/libparted-sys.svg)](https://crates.io/crates/libparted-sys)
 
 requires libparted-dev installed to build on debian variants.

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rustc-link-lib=parted");
+    println!("cargo:rustc-link-lib=parted-fs-resize");
 
     let bindings = bindgen::Builder::default()
     .header("wrapper.h")

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,7 +1,1 @@
-#include <parted/device.h>
-#include <parted/disk.h>
-#include <parted/filesys.h>
-#include <parted/geom.h>
-#include <parted/natmath.h>
 #include <parted/parted.h>
-#include <parted/unit.h>


### PR DESCRIPTION
- Allow use of resize functions. These functions are defined in the headers, but only available if parted-fs-resize is linked
- Simplify wrapper. parted.h imports the other headers, so only parted.h needs to be imported
- Fix README name