### PR TITLE
Generate (non-exhaustive) enums instead of constants

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,14 @@ fn main() {
 
     let bindings = bindgen::Builder::default()
     .header("wrapper.h")
+    .rustified_non_exhaustive_enum("PedDeviceType")
+    .rustified_non_exhaustive_enum("PedUnit")
+    .rustified_non_exhaustive_enum("_PedDiskFlag")
+    .rustified_non_exhaustive_enum("_PedDiskTypeFeature")
+    .rustified_non_exhaustive_enum("_PedExceptionOption")
+    .rustified_non_exhaustive_enum("_PedExceptionType")
+    .rustified_non_exhaustive_enum("_PedPartitionFlag")
+    .rustified_non_exhaustive_enum("_PedPartitionType")
     .generate()
     .expect("Unable to generate bindings");
 


### PR DESCRIPTION
This change will bring the API much closer to how it was before #5 by forcing bindgen to generate enums instead of constants.

It's still a breaking change as the enums are now marked as non-exhaustive, as recommended by the bindgen docs, which avoids problems like [this one](https://github.com/rust-lang/rust/issues/36927).