### PR TITLE
Update bindgen to v0.65

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["parted", "libparted"]
 
 
 [build-dependencies]
-bindgen = "~0.58"
+bindgen = "~0.65"
 
 [dependencies]
 


### PR DESCRIPTION
bindgen ~0.58 depends nom v5, This dependency uses a feature that cargo has marked for future deprecation, so update bindgen to v0.65